### PR TITLE
fix(eslint): force kebab-case as template casing

### DIFF
--- a/vue.js
+++ b/vue.js
@@ -42,11 +42,11 @@ module.exports = {
 			singleline: 5
 		}],
 		'vue/component-name-in-template-casing': ['error', 'kebab-case', {
-    			registeredComponentsOnly: true,
-    			ignores: []
+			registeredComponentsOnly: true,
+			ignores: []
   		}],
 		'vue/component-tags-order': ['error', {
-    			'order': [ 'script', 'template', 'style' ]
+			'order': [ 'script', 'template', 'style' ]
 		}],
 		'vue/multi-word-component-names': 'off',
 		'vue/array-bracket-spacing': ['error', 'never'],

--- a/vue.js
+++ b/vue.js
@@ -42,7 +42,7 @@ module.exports = {
 			singleline: 5
 		}],
 		'vue/component-name-in-template-casing': ['error', 'kebab-case', {
-			registeredComponentsOnly: true,
+			registeredComponentsOnly: false,
 			ignores: []
   		}],
 		'vue/component-tags-order': ['error', {

--- a/vue.js
+++ b/vue.js
@@ -41,8 +41,12 @@ module.exports = {
 		'vue/max-attributes-per-line': ['warn', { 
 			singleline: 5
 		}],
+		'vue/component-name-in-template-casing': ['error', 'kebab-case', {
+    			registeredComponentsOnly: true,
+    			ignores: []
+  		}],
 		'vue/component-tags-order': ['error', {
-    	'order': [ 'script', 'template', 'style' ]
+    			'order': [ 'script', 'template', 'style' ]
 		}],
 		'vue/multi-word-component-names': 'off',
 		'vue/array-bracket-spacing': ['error', 'never'],


### PR DESCRIPTION
Force kebab-case as template casing.

What is your preferred value for `registeredComponentsOnly`?